### PR TITLE
Allow project cards to act as links

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -199,11 +199,14 @@ nav {
 }
 
 .project-card {
+    display: block;
     background-color: var(--secondary-color);
     border-radius: 10px;
     overflow: hidden;
     box-shadow: 0 4px 15px rgba(0, 0, 0, 0.2);
     transition: transform 0.3s ease, box-shadow 0.3s ease;
+    color: inherit;
+    text-decoration: none;
 }
 
 .project-card:hover {

--- a/js/script.js
+++ b/js/script.js
@@ -43,7 +43,7 @@ document.addEventListener('DOMContentLoaded', () => {
     if (projectsGrid) {
         projects.forEach(project => {
             const projectCard = `
-                <div class="project-card">
+                <a href="${project.liveUrl}" class="project-card">
                     <img src="${project.image}" alt="${project.title}">
                     <div class="project-info">
                         <h3>${project.title}</h3>
@@ -51,12 +51,9 @@ document.addEventListener('DOMContentLoaded', () => {
                         <div class="project-tags">
                             ${project.tags.map(tag => `<span>${tag}</span>`).join('')}
                         </div>
-                        <div class="project-links">
-                            ${project.liveUrl ? `<a href="${project.liveUrl}">Link</a>` : ''}
-                            ${project.repoUrl ? `<a href="${project.repoUrl}" target="_blank">GitHub Repo</a>` : ''}
-                        </div>
+                        ${project.repoUrl ? `<div class="project-links"><a href="${project.repoUrl}" target="_blank">GitHub Repo</a></div>` : ''}
                     </div>
-                </div>
+                </a>
             `;
             projectsGrid.innerHTML += projectCard;
         });
@@ -116,7 +113,7 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     // --- Image Lightbox ---
-    const galleryImages = document.querySelectorAll('.gallery-item img, .project-card img');
+    const galleryImages = document.querySelectorAll('.gallery-item img');
     if (galleryImages.length > 0) {
         const lightbox = document.createElement('div');
         lightbox.id = 'lightbox';


### PR DESCRIPTION
## Summary
- make the whole project card a link
- remove the separate "Link" text
- disable lightbox on project thumbnails
- style project cards when used as anchors

## Testing
- `

------
https://chatgpt.com/codex/tasks/task_e_685af48f60ec832f8da13416470e7b0e